### PR TITLE
Temporarily changes BrowserRouter to HashRouter

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter, Route } from 'react-router-dom';
+import { HashRouter, Route } from 'react-router-dom';
 
 import FrontPage from './pages/FrontPage';
 import AboutPage from './pages/AboutPage';
@@ -10,7 +10,7 @@ import RegistrationPage from './pages/RegistrationPage';
 export default class App extends React.Component {
   render() {
     return (
-      <BrowserRouter>
+      <HashRouter>
         <div>
           <Route exact path='/' component={FrontPage} />
           <Route path='/about' component={AboutPage} />
@@ -18,7 +18,7 @@ export default class App extends React.Component {
           <Route path='/guests' component={GuestsPage} />
           <Route path='/registration' component={RegistrationPage} />
         </div>
-      </BrowserRouter>
+      </HashRouter>
     );
   }
 }


### PR DESCRIPTION
Simple change from `BrowserRouter` to `HashRouter`. Ideally, this is a temporary fix and should be changed back to `BrowserRouter` after implementing a "catch-all" solution. The solution should then evolve to an "isomorphic" solution.

The solutions inspired by this post: https://stackoverflow.com/questions/27928372/react-router-urls-dont-work-when-refreshing-or-writting-manually/36623117#36623117