### PR TITLE
Fixes the colors for the navbar hover links

### DIFF
--- a/src/styles/base/_base.scss
+++ b/src/styles/base/_base.scss
@@ -13,6 +13,10 @@ body {
 
 a {
   color: #e62325;
+
+  &:hover {
+    color: #ff5c49;
+  }
 }
 
 h1,

--- a/src/styles/components/_navbar.scss
+++ b/src/styles/components/_navbar.scss
@@ -28,7 +28,7 @@
   transition: 500ms;
 
   &:hover {
-    background-color: #deedf7;
+    background-color: #aa231f;
     transition: 200ms;
   }
 }


### PR DESCRIPTION
The navbar links were blue when hovered over. They are now variants of red.