### PR TITLE
Fixes the burg menu glitch

### DIFF
--- a/src/styles/components/_navburger.scss
+++ b/src/styles/components/_navburger.scss
@@ -10,7 +10,7 @@
 .navburger__list {
   position: absolute;
   top: -1.75rem;
-  left: 0;
+  left: -100%;
   transform-origin: 0% 0%;
   transform: translate(-100%, 0);
   transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0);
@@ -109,5 +109,5 @@
 }
 
 #menuToggle input:checked ~ ul {
-  transform: none;
+  transform: translate(100%, 0);
 }


### PR DESCRIPTION
When the page first loads, the burger menu can be seen briefly before it hides. This PR fixes that by moving the menu offscreen to the left.