### PR TITLE
Applies submenu opening and closing animations

### DIFF
--- a/src/components/NavBurger.js
+++ b/src/components/NavBurger.js
@@ -72,10 +72,12 @@ export default class NavBurger extends React.Component {
   toggleSubMenu = (parentIndex) => {
     const childIndex = this.state.parents.indexOf(parentIndex);
     const subMenu = document.getElementsByClassName('navburger__sub')[childIndex];
-    if (!subMenu.style.maxHeight || subMenu.style.maxHeight === '0px') {
-      subMenu.style.maxHeight = '100%';
-    } else {
-      subMenu.style.maxHeight = '0';
+    if (!subMenu.style.height || subMenu.style.height === '0px' || subMenu.style.transform === 'scaleY(0)') {
+      subMenu.style.transform = 'scaleY(1)';
+      subMenu.style.height = 'auto';
+    } else if (subMenu.style.transform === 'scaleY(1)') {
+      subMenu.style.transform = 'scaleY(0)';
+      setTimeout(() => { subMenu.style.height = '0px' }, 200);
     }
   }
 

--- a/src/styles/components/_navburger.scss
+++ b/src/styles/components/_navburger.scss
@@ -45,9 +45,30 @@
 
 .navburger__sub {
   margin: 0;
-  list-style-type: none;
-  max-height: 0;
+  height: 0px;
   overflow-y: hidden;
+  list-style-type: none;
+  transform: scaleY(0);
+  animation-name: expandSubMenu;
+  transform-origin: 0% 0%;
+  transition-duration: 0.2s;
+}
+
+@keyframes expandSubMenu {
+  0% {
+    height: 0px;
+    transform: scaleY(0);
+  }
+
+  50% {
+    height: auto;
+    transform: scaleY(0.5);
+  }
+
+  100% {
+    height: 100%;
+    transform: scaleY(1);
+  }
 }
 
 .navburger__sub-item {


### PR DESCRIPTION
Using some Javascript magic, we are now able to give the opening and closing submenus some animation without hard-coding their container heights.